### PR TITLE
fix: character set was not correctly parsed

### DIFF
--- a/lib/HL7Message.js
+++ b/lib/HL7Message.js
@@ -112,7 +112,7 @@ class HL7Message {
       let l = 0;
       do {
         k = l + 1;
-        l = buf.indexOf(sep, k);
+        l = Math.min(buf.indexOf(sep, k), crIdx);
         if (l < 0)
           l = buf.length - 1;
         if (i++ === 17) {


### PR DESCRIPTION
It was wrongly returning value `UNICODE UTF-8\rPID`.
My change makes sure that it doesn't overflow into next line, so it will return `UNICODE UTF-8`.