### PR TITLE
fix: iconv doesn't recognize UNICODE* encodings

### DIFF
--- a/lib/HL7Message.js
+++ b/lib/HL7Message.js
@@ -120,7 +120,7 @@ class HL7Message {
           break;
         }
       } while (l > 0 && l < crIdx);
-      str = iconv.decode(buf, encoding);
+      str = iconv.decode(buf, encoding.replace(/^UNICODE /, ''));
     } else
       str = String(buf);
 


### PR DESCRIPTION
HL7 character encodings for UTF* have prefix UNICODE, for example `UNICODE UTF-8`.
`iconv` library doesn't support this encoding string.
My change removed the prefix when calling `iconv.decode`.