### PR TITLE
WIP: Add support for custom segments

### DIFF
--- a/lib/HL7Field.js
+++ b/lib/HL7Field.js
@@ -14,8 +14,10 @@ class HL7Field {
    * @param {HL7Segment} segment
    * @param {string} name
    * @param {Object} def
+   * @param {Object} [customDict]
+   * @param {Object} [customDict.fields]
    */
-  constructor(segment, name, def) {
+  constructor(segment, name, def, customDict) {
     Object.defineProperty(this, '_segment', {
       value: segment,
       enumerable: false
@@ -23,6 +25,7 @@ class HL7Field {
     this._name = name;
     this._def = def;
     this._data = null;
+    this._customDict = customDict;
   }
 
   /**
@@ -131,7 +134,7 @@ class HL7Field {
 
   add() {
     this._data = this._data || [];
-    const data = new HL7FieldData(this, this._def);
+    const data = new HL7FieldData(this, this._def, undefined, this._customDict);
     const k = this._data.length;
     this._data.push(data);
     Object.defineProperty(this, k, {

--- a/lib/HL7FieldData.js
+++ b/lib/HL7FieldData.js
@@ -15,8 +15,10 @@ class HL7FieldData {
    * @param {HL7Field} field
    * @param {Object} def
    * @param {Number} level
+   * @param {Object} [customDict]
+   * @param {Object} [customDict.fields]
    */
-  constructor(field, def, level) {
+  constructor(field, def, level, customDict = {fields: {}}) {
     Object.defineProperty(this, '_field', {
       value: field,
       enumerable: false
@@ -25,8 +27,10 @@ class HL7FieldData {
     this._level = level || 0;
     this._items = null;
     this._value = null;
+    this._customDict = customDict;
 
     const dict = require('./dictionary/' + this.message.version);
+    dict.fields = {...dict.fields, ...this._customDict.fields};
     const fldDict = dict.fields[def.dt];
     /* istanbul ignore next */
     if (!fldDict)
@@ -50,7 +54,7 @@ class HL7FieldData {
   defineComponent(sequence, def) {
     this._items = this._items || [];
     const index = sequence - 1;
-    const comp = new HL7FieldData(this._field, def, 1);
+    const comp = new HL7FieldData(this._field, def, 1, this._customDict);
     Object.defineProperty(this, sequence, {
       get: () => this._items[index],
       enumerable: false

--- a/lib/HL7Message.js
+++ b/lib/HL7Message.js
@@ -25,11 +25,13 @@ class HL7Message {
 
   /**
    * @param {Object} [options]
+   * @param {Object} [options.customDict]
    */
   constructor(options) {
     options = options || {};
     this.version = options.version;
     this._segments = [];
+    this._customDict = options.customDict;
   }
 
   /**
@@ -97,10 +99,15 @@ class HL7Message {
    * @param {Buffer|Uint8Array|string} buf
    * @param {Object} [options]
    * @param {string} [options.encoding='utf8']
+   * @param {Object} [options.customDict]
    * @private
    */
   parse(buf, options) {
     this._segments = [];
+    if (options && options.customDict) {
+      this._customDict = options.customDict;
+    }
+
     let str;
     if (buf instanceof Uint8Array) {
       let encoding = (options && options.encoding) || 'utf8';
@@ -141,7 +148,7 @@ class HL7Message {
     for (const [i, line] of lines.entries()) {
       if (!line)
         continue;
-      const segment = new HL7Segment(this);
+      const segment = new HL7Segment(this, {customDict: this._customDict});
       try {
         segment.parse(line);
       } catch (e) {
@@ -164,7 +171,7 @@ class HL7Message {
   }
 
   static parse(input, options) {
-    const msg = new HL7Message();
+    const msg = new HL7Message(options);
     msg.parse(input, options);
     return msg;
   }

--- a/lib/HL7Message.js
+++ b/lib/HL7Message.js
@@ -139,7 +139,7 @@ class HL7Message {
 
     const lines = str.split(/\r|\r\n|\n/);
     for (const [i, line] of lines.entries()) {
-      if (!line)
+      if (!line || line[0] === 'Z')
         continue;
       const segment = new HL7Segment(this);
       try {

--- a/lib/HL7Message.js
+++ b/lib/HL7Message.js
@@ -139,7 +139,7 @@ class HL7Message {
 
     const lines = str.split(/\r|\r\n|\n/);
     for (const [i, line] of lines.entries()) {
-      if (!line || line[0] === 'Z')
+      if (!line)
         continue;
       const segment = new HL7Segment(this);
       try {

--- a/lib/HL7Segment.js
+++ b/lib/HL7Segment.js
@@ -27,14 +27,33 @@ class HL7Segment {
   /**
    *
    * @param {HL7Message} message
+   * @param {Object} [options]
+   * @param {Object} [options.customDict]
    */
-  constructor(message) {
+  constructor(message, options) {
     Object.defineProperty(this, '_message', {
       value: message,
       enumerable: false
     });
     this._type = null;
     this._fields = null;
+    if (options && options.customDict) {
+      this._customDict = options.customDict;
+    }
+  }
+
+  getDict(version) {
+    const dict = require(path.resolve(__dirname, 'dictionary', version));
+    return {
+      fields: {
+        ...dict.fields,
+        ...(this._customDict || {}).fields
+      },
+      segments: {
+        ...dict.segments,
+        ...(this._customDict || {}).segments
+      }
+    };
   }
 
   /**
@@ -71,7 +90,7 @@ class HL7Segment {
     if (typeof def !== 'object')
       throw new ArgumentError('You must provide config object');
 
-    const dict = require(path.resolve(__dirname, 'dictionary', this.message.version));
+    const dict = this.getDict(this.message.version);
     const dataType = def.dt;
     const fldDict = dict.fields[dataType];
     if (!fldDict)
@@ -81,7 +100,7 @@ class HL7Segment {
     const name = def.desc ?
         capitalizeFirst(def.desc).replace(/[^\w]/g, '') :
         'CustomField' + sequence;
-    const field = this._fields[index] = new HL7Field(this, name, def);
+    const field = this._fields[index] = new HL7Field(this, name, def, this._customDict);
     delete this[sequence];
     delete this[name];
     Object.defineProperty(this, sequence, {
@@ -107,8 +126,8 @@ class HL7Segment {
 
     const segmentType = values[0];
     const sequence = values[1];
-    const dict = require(path.resolve(__dirname, 'dictionary', this.message.version));
-    const segDict = segmentType[0] === 'Z' ? { desc: 'CustomSegment', fields: [] } : dict.segments[segmentType];
+    const dict = this.getDict(this.message.version);
+    const segDict = dict.segments[segmentType];
     if (!segDict) {
       const e = new ParseError('Unknown HL7 segment type (%s)', segmentType);
       e.segmentId = segmentType;

--- a/lib/HL7Segment.js
+++ b/lib/HL7Segment.js
@@ -108,7 +108,7 @@ class HL7Segment {
     const segmentType = values[0];
     const sequence = values[1];
     const dict = require(path.resolve(__dirname, 'dictionary', this.message.version));
-    const segDict = dict.segments[segmentType];
+    const segDict = segmentType[0] === 'Z' ? { desc: 'CustomSegment', fields: [] } : dict.segments[segmentType];
     if (!segDict) {
       const e = new ParseError('Unknown HL7 segment type (%s)', segmentType);
       e.segmentId = segmentType;

--- a/lib/exchange/HL7Client.js
+++ b/lib/exchange/HL7Client.js
@@ -17,10 +17,25 @@ class HL7Client extends EventEmitter {
 
   /**
    *
-   * @param {net.Socket} [socket]
+   * @param {net.Socket|Object} [param1]
+   * @param {Object} [param2]
+   * @param {Object} [param2.customDict]
    */
-  constructor(socket) {
+  constructor(param1, param2) {
     super();
+    let options;
+    let socket = undefined;
+    if (param2 !== undefined) {
+      socket = param1;
+      options = param2 || {};
+    } else if (param1 instanceof net.Socket) {
+      socket = param1;
+    } else {
+      options = param1;
+    }
+
+    if (options && options.customDict)
+      this._customDict = options.customDict;
     if (socket && !(socket instanceof net.Socket))
       throw new ArgumentError('You can provide Socket instance as fist argument');
     this._extSocket = socket;
@@ -214,7 +229,7 @@ class HL7Client extends EventEmitter {
   send(msg) {
     return new Promise(resolve => {
       if (typeof msg === 'string')
-        msg = HL7Message.parse(msg);
+        msg = HL7Message.parse(msg, {customDict: this._customDict});
 
       /* istanbul ignore next */
       if (!(msg instanceof HL7Message))
@@ -248,7 +263,7 @@ class HL7Client extends EventEmitter {
   sendReceive(msg, timeout) {
     return Promise.resolve().then(() => {
       if (typeof msg === 'string')
-        msg = HL7Message.parse(msg);
+        msg = HL7Message.parse(msg, { customDict: this._customDict });
     }).then(() => this.send(msg))
         .then(() => {
 
@@ -293,7 +308,7 @@ class HL7Client extends EventEmitter {
   _onHL7Data(data) {
     let msg;
     try {
-      msg = HL7Message.parse(data, {encoding: this.encoding});
+      msg = HL7Message.parse(data, { encoding: this.encoding, customDict: this._customDict });
     } catch (e) /* istanbul ignore next */ {
       e.message = 'Invalid HL7 data received from server. ' + e.message;
       this.emitSafe('error', e);

--- a/lib/exchange/HL7Server.js
+++ b/lib/exchange/HL7Server.js
@@ -12,6 +12,7 @@ const iconv = require('iconv-lite');
 const HL7Message = require('../HL7Message');
 const HL7MessageRouter = require('./HL7MessageRouter');
 const HL7ProtocolBuffer = require('./HL7ProtocolBuffer');
+const HL7Segment = require('../HL7Segment')
 const {xVT, xFS, xCR} = require('../types');
 
 class HL7Server extends EventEmitter {
@@ -28,6 +29,7 @@ class HL7Server extends EventEmitter {
    * @param {string} [param2.cert]
    * @param {string} [param2.key]
    * @param {boolean} [param2.rejectUnauthorized]
+   * @param {Object} [param2.customDict]
    */
   constructor(param1, param2) {
     super();
@@ -56,6 +58,7 @@ class HL7Server extends EventEmitter {
         options.maxBufferPerSocket : 5;
     this.shutdownWait = options.shutdownWait;
     this._controlIdSeq = 0;
+    this._customDict = options.customDict
 
     this._connectionListener = (socket) => this._onConnect(socket);
     this._closeListener = (...args) => this.emitSafe('close', ...args);
@@ -227,7 +230,7 @@ class HL7Server extends EventEmitter {
     let msg;
     // Parse message
     try {
-      msg = HL7Message.parse(block, {encoding: this.defaultEncoding});
+      msg = HL7Message.parse(block, {encoding: this.defaultEncoding, customDict: this._customDict});
       socket._errorCount = 0;
     } catch (e) {
       const ack = this._createACK(msg, 'AR',
@@ -287,7 +290,7 @@ class HL7Server extends EventEmitter {
     return new Promise(resolve => {
       /* istanbul ignore next: same in client */
       if (typeof msg === 'string')
-        msg = HL7Message.parse(msg);
+        msg = HL7Message.parse(msg, {customDict: this._customDict});
 
       /* istanbul ignore next */
       if (!(msg instanceof HL7Message))
@@ -317,7 +320,8 @@ class HL7Server extends EventEmitter {
    */
   _createACK(req, ackCode, textMessage) {
     const ack = new HL7Message({
-      version: (req && req.MSH.VersionId.value) || '2.5'
+      version: (req && req.MSH.VersionId.value) || '2.5',
+      customDict: this._customDict
     });
     const msh = ack.add('MSH');
     msh[3].value = this.applicationName;

--- a/test/03_parse.js
+++ b/test/03_parse.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 const assert = require('assert');
 const {HL7Message} = require('../');
+const HL7Segment = require('../lib/HL7Segment')
 const {VT, FS, CR} = require('../lib/types');
 
 const sampleMessage1 = `MSH|^~\\&|LCS|LCA|LIS|TEST9999|19980731153200||ORU^R01|3629|P|2.2
@@ -254,4 +255,45 @@ describe('Parse HL7 message', function() {
     assert.strictEqual(msg.MSH.CustomField18.value, '1234');
   });
 
+
+  it('should parse custom segments', function() {
+    const messageString = sampleMessage1 + '\rZDS|1.2.345.67.8.9.12341234123412.345|1.2.345.67.8.9.12341234123412.345';
+
+    const customDict = {
+      segments: {
+        ZDS: {
+          desc: '',
+          fields: [
+            {
+              dt: 'RP',
+              desc: 'Study Instance UID',
+              opt: 'R',
+              rep: 1
+            },
+            {
+              dt: 'ST',
+              desc: 'pointer',
+              opt: 'R',
+              rep: 1
+            }
+          ]
+        }
+      },
+      fields: {
+        RP: {
+          desc: "Reference Pointer",
+          components: [
+            {
+              dt: 'ST',
+              desc: 'pointer',
+              opt: 'O',
+              rep: 1
+            }
+          ]
+        }
+      }
+    };
+
+    HL7Message.parse(messageString, { customDict })
+  })
 });


### PR DESCRIPTION
The commits in this pull request are related to #15.

The first commit makes it possible to use this library with HL7 interfaces that use custom segments by ignoring them altogether. This of course means that the implementation cannot reference the segments data.

The second commit creates `CustomSegmentX` segments and `CustomFieldX` fields that store the data as a string.

The third commit adds a static customDict object to the HL7Segment class that is merged with the dictionary defined by the version number. This allows the client and server to handle messages with custom segments and ensures the message content is parsed according to the schema in the dictionary.

The implementation is very rudimentary and is meant as a conversation starter. Please comment on whether you think these changes are feasible or if you know of some cases where this implementation will not work.