### PR TITLE
Allow client certificate free TLS connections

### DIFF
--- a/lib/exchange/HL7Client.js
+++ b/lib/exchange/HL7Client.js
@@ -147,7 +147,7 @@ class HL7Client extends EventEmitter {
       this._buffer.on('block', data => this._onHL7Data(data));
 
       this._socket = socket = socket ||
-          (opts.cert ? tls.connect(opts) : net.connect(opts));
+          (opts.protocol === 'mllps' || opts.cert ? tls.connect(opts) : net.connect(opts));
 
       socket.removeListener('connect', this._connectionListener);
       socket.removeListener('secureConnect', this._connectionListener);


### PR DESCRIPTION
Not all TLS/SSL connections require a client certificate. While client validation is desirable in production settings, it should not be forced onto the end user.

I have a project that uses your client to connect to various HL7 servers. In production use cases it's fine, but when I tried to set up an MLLPS connection in a development context with no client certificate I realized this library wouldn't let me.

I made a local tweak to verify it worked, and decided to submit a pull request. Thank you for your consideration.