### PR TITLE
Improve character encoding support

### DIFF
--- a/lib/HL7Message.js
+++ b/lib/HL7Message.js
@@ -94,7 +94,7 @@ class HL7Message {
 
   /**
    *
-   * @param {Buffer|Uint8Array|string} buf
+   * @param {Buffer|string} buf
    * @param {Object} [options]
    * @param {string} [options.encoding='utf8']
    * @private
@@ -102,7 +102,7 @@ class HL7Message {
   parse(buf, options) {
     this._segments = [];
     let str;
-    if (buf instanceof Uint8Array) {
+    if (buf instanceof Buffer) {
       let encoding = (options && options.encoding) || 'utf8';
       /* Character set detection */
       const sep = FIELD_SEPARATOR.charCodeAt(0);
@@ -121,8 +121,11 @@ class HL7Message {
         }
       } while (l > 0 && l < crIdx);
       str = iconv.decode(buf, encoding.replace(/^UNICODE/, ''));
-    } else
-      str = String(buf);
+    } else if (typeof buf === 'string') {
+      str = buf;
+    } else {
+      throw new ArgumentError('You must provide string or Buffer argument');
+    }
 
     if (str.startsWith(VT))
       str = str.substring(1);

--- a/lib/exchange/HL7Client.js
+++ b/lib/exchange/HL7Client.js
@@ -228,7 +228,7 @@ class HL7Client extends EventEmitter {
         msg.MSH.MessageControlId.value = ++this._controlIdSeq;
 
       const str = msg.toHL7();
-      let charset = 'utf8';
+      let charset = this.encoding || 'utf8';
       if (msg.MSH[18]) {
         if (this.encoding && !msg.MSH[18].value)
           msg.MSH[18].value = this.encoding;

--- a/lib/exchange/HL7Server.js
+++ b/lib/exchange/HL7Server.js
@@ -22,7 +22,7 @@ class HL7Server extends EventEmitter {
    * @param {Object} [param2]
    * @param {string} [param2.applicationName]
    * @param {string} [param2.facilityName]
-   * @param {string} [param2.defaultEncoding]
+   * @param {string} [param2.encoding]
    * @param {string} [param2.defaultVersion]
    * @param {number} [param2.maxBufferPerSocket]
    * @param {string} [param2.cert]
@@ -227,7 +227,7 @@ class HL7Server extends EventEmitter {
     let msg;
     // Parse message
     try {
-      msg = HL7Message.parse(block, {encoding: this.defaultEncoding});
+      msg = HL7Message.parse(block, {encoding: this.encoding});
       socket._errorCount = 0;
     } catch (e) {
       const ack = this._createACK(msg, 'AR',
@@ -295,7 +295,7 @@ class HL7Server extends EventEmitter {
         throw new ArgumentError('You must provide HL7Message or string argument');
 
       const str = msg.toHL7();
-      let charset = 'utf8';
+      let charset = this.encoding || 'utf8';
       /* istanbul ignore next: same in client */
       if (msg.MSH[18]) {
         if (this.encoding && !msg.MSH[18].value)

--- a/lib/exchange/HL7Server.js
+++ b/lib/exchange/HL7Server.js
@@ -220,7 +220,7 @@ class HL7Server extends EventEmitter {
   /**
    *
    * @param {net.Socket} socket
-   * @param {string} block
+   * @param {Buffer} block
    * @private
    */
   _onHl7Block(socket, block) {

--- a/test/03_parse.js
+++ b/test/03_parse.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 const assert = require('assert');
+const iconv = require('iconv-lite');
 const {HL7Message} = require('../');
 const {VT, FS, CR} = require('../lib/types');
 
@@ -223,6 +224,14 @@ describe('Parse HL7 message', function() {
     msg = HL7Message.parse(buf);
     assert(msg.MSH);
     assert.strictEqual(msg.MSH.CharacterSet.value, 'UTF-8');
+  });
+
+  it('should parse from ISO 8859-1 encoded Buffer given encoding', function() {
+    const encoding = 'iso-8859-1';
+    let buf = iconv.encode(VT + 'MSH|^~\\\\&|APP|Scandinavian facility åäöÅÄÖæøÆØ||||||||2.5|||||' + CR + FS, encoding);
+    let msg = HL7Message.parse(buf, { encoding });
+    assert(msg.MSH);
+    assert.strictEqual(msg.MSH.SendingFacility.value, 'Scandinavian facility åäöÅÄÖæøÆØ');
   });
 
   it('should message start with MSH segment', function() {

--- a/test/07_protocolbuffer.js
+++ b/test/07_protocolbuffer.js
@@ -106,4 +106,20 @@ describe('HL7ProtocolBuffer', function() {
     p.write(VT + 'MSH|^~\\&||||||||||2.7.1' + FS + CR);
   });
 
+  it('Should emit blocks as Buffer instances', function(done) {
+    const p = new HL7ProtocolHandler();
+    let tests;
+    p.on('block', (data) => {
+      assert(data instanceof Buffer);
+      assert.strictEqual(data.toString(), VT + 'MSH|^~\\&||||||||||2.7.1' + CR + FS);
+      if (tests === 0) done();
+    });
+
+    const msg = VT + 'MSH|^~\\&||||||||||2.7.1' + CR + FS;
+    tests = 3;
+    --tests, p.write(msg);
+    --tests, p.write(Buffer.from(msg));
+    --tests, p.write([...Buffer.from(msg)]);
+  })
+
 });

--- a/test/09_server.js
+++ b/test/09_server.js
@@ -174,6 +174,45 @@ describe('HL7Server', function() {
     }).catch((e) => done(e));
   });
 
+  it('should receive hl7 messages and send response with ISO 8859-1 encoding', function(done) {
+    const encoding = 'iso-8859-1';
+
+    const sampleIso8859Message1 = sampleMessage1.replace('TESTPAT', 'Scandinavian patient åäöÅÄÖæøÆØ');
+    const iso8859Ack1 = ack1.replace('StJohn', 'Scandinavian hospital åäöÅÄÖæøÆØ');
+
+    server = new HL7Server({ encoding });
+
+    // Simulate client using ISO 8859-1 encoding
+    const client = new HL7Client();
+    client.setEncoding(encoding);
+
+    server.listen(8080).then(() => {
+      const msg = HL7Message.parse(sampleIso8859Message1);
+      const ack = HL7Message.parse(iso8859Ack1);
+
+      server.use((req) => {
+        try {
+          assert.strictEqual(req.getSegment('PID').PatientName[0].GivenName.value, 'Scandinavian patient åäöÅÄÖæøÆØ');
+          return ack;
+        } catch (e) {
+          done(e);
+        }
+      });
+
+      client.connect(8080).then(() => {
+        client.sendReceive(msg).then(res => {
+          try {
+            assert.strictEqual(ack.toHL7(), res.toHL7());
+            assert.strictEqual(res.MSH.ReceivingFacility.value, 'Scandinavian hospital åäöÅÄÖæøÆØ');
+            server.close().then(() => done());
+          } catch (e) {
+            done(e);
+          }
+        });
+      });
+    }).catch((e) => done(e));
+  });
+
   it('should send nak if no middle-ware matches', function(done) {
     server = new HL7Server();
     server.listen(8080).then(() => {


### PR DESCRIPTION
I work in a project that uses this library. The system we are integrating against sends HL7 messages with the ISO 8859-1 / latin1 character encoding. Unfortunately the system does not specify the encoding in the [HL7 MSH.18 field](https://hl7-definition.caristix.com/v2/HL7v2.5/Fields/MSH.18) so we have to specify the encoding from the library API. When trying to do this I discovered that supplying the character encoding to `HL7Server` and `HL7Client` instances dit not fully work. This PR fixes the issues and adds test to verify that the specified encoding is used.