### PR TITLE
Fix reverted HL7 message terminators in tests

### DIFF
--- a/test/03_parse.js
+++ b/test/03_parse.js
@@ -228,7 +228,7 @@ describe('Parse HL7 message', function() {
 
   it('should parse from ISO 8859-1 encoded Buffer given encoding', function() {
     const encoding = 'iso-8859-1';
-    let buf = iconv.encode(VT + 'MSH|^~\\\\&|APP|Scandinavian facility åäöÅÄÖæøÆØ||||||||2.5|||||' + CR + FS, encoding);
+    let buf = iconv.encode(VT + 'MSH|^~\\\\&|APP|Scandinavian facility åäöÅÄÖæøÆØ||||||||2.5|||||' + FS + CR, encoding);
     let msg = HL7Message.parse(buf, { encoding });
     assert(msg.MSH);
     assert.strictEqual(msg.MSH.SendingFacility.value, 'Scandinavian facility åäöÅÄÖæøÆØ');

--- a/test/07_protocolbuffer.js
+++ b/test/07_protocolbuffer.js
@@ -111,11 +111,11 @@ describe('HL7ProtocolBuffer', function() {
     let tests;
     p.on('block', (data) => {
       assert(data instanceof Buffer);
-      assert.strictEqual(data.toString(), VT + 'MSH|^~\\&||||||||||2.7.1' + CR + FS);
+      assert.strictEqual(data.toString(), VT + 'MSH|^~\\&||||||||||2.7.1' + FS + CR);
       if (tests === 0) done();
     });
 
-    const msg = VT + 'MSH|^~\\&||||||||||2.7.1' + CR + FS;
+    const msg = VT + 'MSH|^~\\&||||||||||2.7.1' + FS + CR;
     tests = 3;
     --tests, p.write(msg);
     --tests, p.write(Buffer.from(msg));


### PR DESCRIPTION
I noticed that I had inadvertently reverted some HL7 message terminators in new tests added in PR #28. This PR fixes the terminators to the correct order and in sync with the rest of the test messages.