### PR TITLE
fix(exchange/server): use named field parameters

### DIFF
--- a/lib/exchange/HL7Server.js
+++ b/lib/exchange/HL7Server.js
@@ -275,8 +275,13 @@ class HL7Server extends EventEmitter {
           const ack = this._createACK(msg, 'AE', 'Internal server error');
           const err = ack.add('ERR');
 
-          const code = err.ApplicationErrorCode.add();
-          code.Text.value = e.message;
+          const version = msg.MSH.Version.value;
+          if (version < '2.5') {
+              err[1].add()[4][2].value = e.message;
+          } else {
+              const code = err.ApplicationErrorCode.add();
+              code.Text.value = e.message;
+          }
 
           this._sendMessage(socket, ack);
         });

--- a/lib/exchange/HL7Server.js
+++ b/lib/exchange/HL7Server.js
@@ -274,7 +274,10 @@ class HL7Server extends EventEmitter {
             return;
           const ack = this._createACK(msg, 'AE', 'Internal server error');
           const err = ack.add('ERR');
-          err[1].add()[4][2].value = e.message;
+
+          const code = err.ApplicationErrorCode.add();
+          code.Text.value = e.message;
+
           this._sendMessage(socket, ack);
         });
   }


### PR DESCRIPTION
Indexes of certain field parameters appear to have changed in some revisions of the HL7 specification. Using the named properties instead of the indexes circumvents the difference in indexing between versions.

Needs evaluation for correctness.

I discovered this error when using `HL7Server` to receive an HL7 v2.7 observation results message (`ORU^R01^ORU^R01`) that was previously generated by `v0.9.0` of this library and throwing from the event handler. This triggers an error acknowledgement, which then attempts to construct an ERR segment using indexes.

Starting in HL7 v2.5, the ERR segment was drastically altered, and the path that was used no longer references what it did in previous iterations. Instead, the path used in the original code path maps to a `Severity` field, which does not contain any sub-structures.

I doubt this fix is correct for all use cases, but works with 2.5+ AFAICT. Happy to implement a complete solution if I can get some guidance.